### PR TITLE
feat: add npm publishing to release workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -25,7 +25,7 @@ jobs:
           # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: config/release-please.json
-  zip-and-upload:
+  publish-and-upload:
     if: needs.release-please.outputs.release_created == 'true'
     needs: release-please
     runs-on: ubuntu-latest
@@ -34,10 +34,21 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
+      
       - uses: oven-sh/setup-bun@v1
+      
       - run: bun install
+      
       - run: bun run compile
-      - name: upload-github-release
+      
+      - name: Publish to npm
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          bun publish --access public
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      
+      - name: Upload binary to GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@elanthia/cartograph",
+  "name": "@elanthia/cartographer",
   "module": "mapdb/index.ts",
   "version": "0.1.0",
   "files": ["mapdb/**/*"],


### PR DESCRIPTION
## Summary
- Add npm publishing step to GitHub Actions release workflow
- Rename job from `zip-and-upload` to `publish-and-upload` for clarity
- Update package name from `@elanthia/cartograph` to `@elanthia/cartographer`
- Maintain existing GitHub release upload functionality

## Test plan
- [ ] Verify workflow runs successfully on merge
- [ ] Confirm npm publishing works with NPM_TOKEN secret
- [ ] Ensure GitHub release upload still functions

🤖 Generated with [Claude Code](https://claude.ai/code)